### PR TITLE
Update for windows compatibility and added elm-test

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,15 +23,16 @@
     "pre-commit-msg": "echo JavaScript Standard Style Check... && exit 0",
     "test": "standard server/**/*.js src/**/*.js && elm-test",
     "start": "node server/main",
-    "prod": "NODE_ENV=production PORT=3000 node server/main",
+    "prod": "cross-env NODE_ENV=production PORT=3000 node server/main",
     "postinstall": "elm-package install",
-    "build": "rimraf dist && NODE_ENV=production webpack --progress --profile --colors"
+    "build": "rimraf dist && cross-env NODE_ENV=production webpack --progress --profile --colors"
   },
   "pre-commit": [
     "pre-commit-msg",
     "test"
   ],
   "dependencies": {
+    "cross-env": "^3.1.3",
     "express": "^4.13.3"
   },
   "devDependencies": {
@@ -40,6 +41,7 @@
     "css-loader": "^0.19.0",
     "elm": "^0.17.1",
     "elm-hot-loader": "^0.3.4",
+    "elm-test": "^0.17.3",
     "elm-webpack-loader": "^3.0.6",
     "extract-text-webpack-plugin": "^0.8.2",
     "html-webpack-plugin": "^1.6.1",


### PR DESCRIPTION
The base version failed when running on windows due to incompatibility of the command line. This is fixed with the cross-env package.

Also, the test failed because elm-test was not included in the package. It may work if elm-test is installed globally, but on the test machine it is not. I simply added elm-test as a dev dependency.